### PR TITLE
Add support for custom dockerfile used for container build

### DIFF
--- a/lib/kitchen/driver/docker_version.rb
+++ b/lib/kitchen/driver/docker_version.rb
@@ -19,6 +19,6 @@ module Kitchen
   module Driver
 
     # Version string for Docker Kitchen driver
-    DOCKER_VERSION = "0.2.2"
+    DOCKER_VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
This adds support for fetching a custom Dockerfile either from a local file or a URL (anything compatible with `open-uri`. The Dockerfile is parsed as erb allowing for more control over the contents of the Dockerfile based on your kitchen config.  
