### PR TITLE
Support HTTP(S) sockets and docker-api's defaults

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -25,7 +25,7 @@ module Kitchen
     # Docker driver
     class Docker < Kitchen::Driver::SSHBase
 
-      default_config :socket,        'unix:///var/run/docker.sock'
+      default_config :socket,        ::Docker.url
       default_config :privileged,    false
       default_config :remove_images, true
       default_config :run_command,   '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no'


### PR DESCRIPTION
- Accept `http` and `https` socket types in addition to `tcp`. I was experimenting with running an HTTPS proxy in front of the Docker API. Everything seems to work once this is applied.
- Use `Docker.url` instead of hardcoding the same unix socket it defaults to. This allows support for the `$DOCKER_URL` environment variable that docker-api checks for.
