### PR TITLE
Update docker-api gem & add tty option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0
+
+* Bump docker-api to 0.10.x. This version is incompatible with docker <
+  0.9, so be sure you are running 0.9+ before using this version.
+* Default to enabling Tty option in docker
+
 ## 0.3.0
 
 * Added support for the `dockerfile` config option

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ could choose to use the CLI or docker-api based client.
 
 * [Docker][docker_getting_started] server. This driver does not require the docker cli to be installed. 
 
+NOTE: As of version 0.4.0 of this driver, you must be running Docker
+v0.9 or higher. This is due to a backward incompatible change in the
+docker-api gem this driver uses. If you must use an older Docker version
+you should run v0.3.0 or lower of this driver. 
+
 ## Installation and Setup
 
 Please read the Test Kitchen [docs][test_kitchen_docs] for more details.

--- a/kitchen-docker-api.gemspec
+++ b/kitchen-docker-api.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'test-kitchen', '>= 1.0.0'
-  spec.add_dependency 'docker-api', '~> 1.9.0'
+  spec.add_dependency 'docker-api', '~> 1.10.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -159,7 +159,8 @@ module Kitchen
           :AttachStdout => true,
           :AttachStderr => true,
           :Privileged => config[:privileged],
-          :PublishAllPorts => false
+          :PublishAllPorts => false,
+          :Tty => true
         }
         # Yes, this key must be a string
         data['name'] = config[:container_name]

--- a/lib/kitchen/driver/docker_version.rb
+++ b/lib/kitchen/driver/docker_version.rb
@@ -19,6 +19,6 @@ module Kitchen
   module Driver
 
     # Version string for Docker Kitchen driver
-    DOCKER_VERSION = "0.3.0"
+    DOCKER_VERSION = "0.4.0"
   end
 end


### PR DESCRIPTION
- Update docker-api gem to 1.10.x making this driver incompatible w/ Docker < 0.9
- Add Tty option (-t for cli) enabled by default
